### PR TITLE
💄: 랜덤 페이지 UI 변경

### DIFF
--- a/src/components/Random/Description.module.scss
+++ b/src/components/Random/Description.module.scss
@@ -3,8 +3,8 @@
   flex-direction: column;
 }
 
-.desc {
-  margin-bottom: 10px;
+.name {
+  margin-bottom: 20px;
 }
 
 .link_div {

--- a/src/components/Random/Description.tsx
+++ b/src/components/Random/Description.tsx
@@ -4,16 +4,17 @@ import { Link } from "react-router-dom";
 import styles from "./Description.module.scss";
 
 interface DescriptionInterface {
-  description: string;
+  name: string;
+  cocktailId: string;
 }
 
-function Description({ description }: DescriptionInterface) {
+function Description({ name, cocktailId }: DescriptionInterface) {
   return (
     <section className={styles.section}>
-      <div className={styles.desc}>{description}</div>
+      <h2 className={styles.name}>{name}</h2>
 
       <div className={styles.link_div}>
-        <Link to="/detail" className={styles.link}>
+        <Link to={`/detail/${cocktailId}`} className={styles.link}>
           Show Detail
         </Link>
       </div>

--- a/src/components/Random/Information.module.scss
+++ b/src/components/Random/Information.module.scss
@@ -1,6 +1,7 @@
 .section {
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .image_div {
@@ -15,17 +16,12 @@
 }
 
 @media (min-width: 768px) {
-  .section {
-    flex-direction: row;
-  }
-
   .image_div {
-    margin-right: 20px;
     width: 50%;
   }
 
   .image {
-    width: 300px;
-    height: 300px;
+    width: 400px;
+    height: 400px;
   }
 }

--- a/src/components/Random/Information.tsx
+++ b/src/components/Random/Information.tsx
@@ -15,7 +15,7 @@ function Information({ random }: any) {
           />
         </div>
 
-        <Description description={random.strInstructions} />
+        <Description name={random.strDrink} cocktailId={random.idDrink} />
       </section>
     )
   );


### PR DESCRIPTION
칵테일 설명을 제거하고, 칵테일 이름을 보여줍니다.
이미지, 이름, 버튼이 column 방향으로 나열됩니다.